### PR TITLE
✏️ deps: Shorten dependabot commit message prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,4 +12,4 @@ updates:
           - "minor"
           - "patch"
     commit-message:
-      prefix: "⬆️ (deps-ghaction):"
+      prefix: "⬆️ gha:"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified the commit message prefix for Dependabot configuration, enhancing clarity and consistency in commit history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->